### PR TITLE
fix: relative effect sizes for negative means

### DIFF
--- a/causalimpact/inferences.py
+++ b/causalimpact/inferences.py
@@ -380,13 +380,15 @@ class Inferences(object):
         sum_abs_effect_lower = sum_post_y - sum_post_pred_upper
         sum_abs_effect_upper = sum_post_y - sum_post_pred_lower
 
-        rel_effect = abs_effect / mean_post_pred
-        rel_effect_lower = abs_effect_lower / mean_post_pred
-        rel_effect_upper = abs_effect_upper / mean_post_pred
+        abs_mean_post_pred = np.abs(mean_post_pred)
+        rel_effect = abs_effect / abs_mean_post_pred
+        rel_effect_lower = abs_effect_lower / abs_mean_post_pred
+        rel_effect_upper = abs_effect_upper / abs_mean_post_pred
 
-        sum_rel_effect = sum_abs_effect / sum_post_pred
-        sum_rel_effect_lower = sum_abs_effect_lower / sum_post_pred
-        sum_rel_effect_upper = sum_abs_effect_upper / sum_post_pred
+        abs_sum_post_pred = np.abs(sum_post_pred)
+        sum_rel_effect = sum_abs_effect / abs_sum_post_pred
+        sum_rel_effect_lower = sum_abs_effect_lower / abs_sum_post_pred
+        sum_rel_effect_upper = sum_abs_effect_upper / abs_sum_post_pred
 
         # Prepares all this data into a DataFrame for later retrieval, such as when
         # running the `summary` method.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -556,6 +556,41 @@ def test_default_causal_inferences(fix_path):
     assert ci.inferences.index.dtype == data.index.dtype
 
 
+def test_default_causal_inferences_negative(fix_path):
+    np.random.seed(1)
+    data = pd.read_csv(os.path.join(fix_path, 'google_data.csv'))
+    del data['t']
+    shift = 200
+    data['y'] =  data['y'] - shift
+
+    pre_period = [0, 60]
+    post_period = [61, 90]
+    cum_shift = (90-60) * shift
+    ci = CausalImpact(data, pre_period, post_period)
+    assert np.floor(ci.summary_data['average']['actual']) == 156 - shift  
+    assert np.floor(ci.summary_data['average']['predicted']) == 129 - shift  
+    assert np.floor(ci.summary_data['average']['predicted_lower']) == 123 - shift + 1 # -1 due to round-off
+    assert np.floor(ci.summary_data['average']['predicted_upper']) == 134 - shift 
+    assert int(ci.summary_data['average']['abs_effect']) == 27
+    assert round(ci.summary_data['average']['abs_effect_lower'], 1) == 21.6
+    assert int(ci.summary_data['average']['abs_effect_upper']) == 31
+    assert round(ci.summary_data['average']['rel_effect'], 1) == 0.4
+    assert round(ci.summary_data['average']['rel_effect_lower'], 2) == 0.30
+    assert round(ci.summary_data['average']['rel_effect_upper'], 2) == 0.45
+    assert np.floor(ci.summary_data['cumulative']['actual']) == 4687 - cum_shift
+    assert np.floor(ci.summary_data['cumulative']['predicted']) == 3876 - cum_shift 
+    assert np.floor(ci.summary_data['cumulative']['predicted_lower']) == 3729 - cum_shift 
+    assert np.floor(ci.summary_data['cumulative']['predicted_upper']) == 4040 - cum_shift 
+    assert int(ci.summary_data['cumulative']['abs_effect']) == 810
+    assert int(ci.summary_data['cumulative']['abs_effect_lower']) == 646
+    assert int(ci.summary_data['cumulative']['abs_effect_upper']) == 957
+    assert round(ci.summary_data['cumulative']['rel_effect'], 1) == 0.4
+    assert round(ci.summary_data['cumulative']['rel_effect_lower'], 2) == 0.30
+    assert round(ci.summary_data['cumulative']['rel_effect_upper'], 2) == 0.45
+
+    assert round(ci.p_value, 1) == 0.0
+    assert ci.inferences.index.dtype == data.index.dtype
+
 def test_default_causal_inferences_w_date(fix_path):
     np.random.seed(1)
     data = pd.read_csv(os.path.join(fix_path, 'google_data.csv'))


### PR DESCRIPTION
Thanks for putting this Python port together!

When working with some negative data I noticed that the relative effects in the summary/report are sometimes unintuitive. For example, currently an increase for negative time series will result in "increase" in the report. 

For example this plot 
![Screen Shot 2020-11-27 at 09 41 58](https://user-images.githubusercontent.com/32935233/100428870-ce567e00-3094-11eb-9f2e-48de018a7999.png)

Would result in the following text
"The above results are given in terms of absolute numbers. In relative terms, the response variable showed an increase of +429.77%. The 95% interval of this percentage is [253.75%, 615.62%]."

To fix this, I think that the relative effect size should be calculated as 

<img src="https://tex.cheminfo.org/?tex=y_%5Cmathrm%7Beffect%7D%20%3D%20%5Cfrac%7B%5Cmathrm%7Babsolute%5C%20effect%7D%7D%7B%5C%7Cy_%5Cmathrm%7Breference%7D%5C%7C%7D"/>

instead of 

<img src="https://tex.cheminfo.org/?tex=y_%5Cmathrm%7Beffect%7D%20%3D%20%5Cfrac%7B%5Cmathrm%7Babsolute%5C%20effect%7D%7D%7By_%5Cmathrm%7Breference%7D%7D"/>

This PR basically just add the `abs()` and a test for data shifted to negative values. 

The original R implementation also does not use the absolute value (https://github.com/google/CausalImpact/blob/60759074a6d909875d064c837495ba80e1417b01/R/impact_inference.R#L249-L252). I'll probably make a PR there this weekend. 